### PR TITLE
Add char support in the lexer

### DIFF
--- a/include/Compiler/Lexer/Lexer.hpp
+++ b/include/Compiler/Lexer/Lexer.hpp
@@ -16,6 +16,7 @@ namespace SunflowerCompiler
         char CurrentChar();
         void Advance();
         void Reset();
+        void Char();
 
     private:
         std::vector<Token> tokens;

--- a/include/Compiler/Lexer/TokenType.hpp
+++ b/include/Compiler/Lexer/TokenType.hpp
@@ -34,6 +34,9 @@ namespace SunflowerCompiler
         UNKNOWN,
         END_OF_FILE,
         INT_NUMBER,
-        FLOAT_NUMBER
+        FLOAT_NUMBER,
+        STRING,
+        CHAR,
+        REGEX
     };
 }

--- a/src/Compiler/Lexer/Lexer.cpp
+++ b/src/Compiler/Lexer/Lexer.cpp
@@ -67,6 +67,11 @@ namespace SunflowerCompiler
                 int start = index;
                 Keyword();
             }
+            else if (CurrentChar() == '\'')
+            {
+                Char();
+                continue;
+            }
             else
             {
                 char currentChar = CurrentChar();
@@ -162,6 +167,23 @@ namespace SunflowerCompiler
         {
             tokens.push_back(Token{value, TokenType::INT_NUMBER});
         }
+    }
+
+    void Lexer::Char()
+    {
+        int start = index;
+        if (CurrentChar() == '\'')
+        {
+            Advance();
+            Advance();
+        }
+        std::string value = source.substr(start, (index - start) + 1);
+        if (CurrentChar() != '\'')
+        {
+            tokens.push_back(Token{value, TokenType::UNKNOWN});
+            return;
+        }
+        tokens.push_back(Token{value, TokenType::CHAR});
     }
 
     void Lexer::Advance()

--- a/test/Lexer/LexerTest.cpp
+++ b/test/Lexer/LexerTest.cpp
@@ -94,6 +94,30 @@ TEST(LexerTest, TestNegativeFloat)
     }
 }
 
+TEST(LexerTest, TestChar)
+{
+    std::string source = "'a'";
+    Lexer lexer(source);
+    lexer.Tokenize();
+    Token token = lexer.GetTokens()[0];
+    std::cout << magic_enum::enum_name(token.type) << std::endl;
+    std::cout << token.name << std::endl;
+    EXPECT_EQ(token.type, TokenType::CHAR);
+    EXPECT_EQ(token.name, "'a'");
+}
+
+TEST(LexerTest, TestCharWithMultipleTokens)
+{
+    std::string source = "return 'a'";
+    Lexer lexer(source);
+    lexer.Tokenize();
+    Token token = lexer.GetTokens()[1];
+    std::cout << magic_enum::enum_name(token.type) << std::endl;
+    std::cout << token.name << std::endl;
+    EXPECT_EQ(token.type, TokenType::CHAR);
+    EXPECT_EQ(token.name, "'a'");
+}
+
 int main(int argc, char **argv)
 {
     ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
### This PR add a basic support for char tokenization in the Lexer.
#### It completes one objective of milestone [Finish The Lexer](https://github.com/lucaasd/sunflower-lang/milestone/1) and issue #5

#### Changes:

- 4071e401dbc8ef505d10cafa326ae0c9262a0955 Added 3 new token types: `CHAR`, `STRING` and `REGEX`
- 49469d641859db730089b6a498b777f52ebea465 Added new Char() method in the lexer header
- 4e2a738ce81b3445f1f88d77c1741dd4fbe0c103 Implemented the Char() method and added the necessary code in the Lexer.cpp file
- 19ee3a75b47eb4e695f98ce2620d0460da95260f Added 2 tests to the new lexer version